### PR TITLE
fix: handle app.activeWindowChanges being possibly undefined

### DIFF
--- a/src/blame.ts
+++ b/src/blame.ts
@@ -4,17 +4,35 @@ import { Settings } from './extension'
 import { resolveURI } from './uri'
 import { memoizeAsync } from './util/memoizeAsync'
 
-/**
- * Queries the blame hunks for the document at the provided URI,
- * and returns blame decorations for all provided selections.
- *
- */
-export const getBlameDecorations = async ({ uri, settings, selections }: { uri: string; settings: Settings, selections: sourcegraph.Selection[] }): Promise<sourcegraph.TextDocumentDecoration[]> => {
-    if (!settings['git.blame.lineDecorations']) {
-        return []
-    }
-    const hunks = await queryBlameHunks(uri)
-    const now = Date.now()
+const getDecorationFromHunk = (hunk: Hunk, now: number, decoratedLine: number): sourcegraph.TextDocumentDecoration => ({
+    range: new sourcegraph.Range(decoratedLine, 0, decoratedLine, 0),
+    isWholeLine: true,
+    after: {
+        light: {
+            color: 'rgba(0, 0, 25, 0.55)',
+            backgroundColor: 'rgba(193, 217, 255, 0.65)',
+        },
+        dark: {
+            color: 'rgba(235, 235, 255, 0.55)',
+            backgroundColor: 'rgba(15, 43, 89, 0.65)',
+        },
+        contentText: `${truncate(hunk.author.person.displayName, 25)}, ${formatDistanceStrict(
+            hunk.author.date,
+            now,
+            {
+                addSuffix: true,
+            }
+        )}: • ${truncate(hunk.message, 45)}`,
+        hoverMessage: `${truncate(hunk.message, 1000)}`,
+        linkURL: `${
+            sourcegraph.internal.clientApplication === 'sourcegraph'
+                ? ''
+                : sourcegraph.internal.sourcegraphURL
+        }${hunk.commit.url}`,
+    },
+})
+
+const getBlameDecorationsForSelections = (hunks: Hunk[], selections: sourcegraph.Selection[], now: number) => {
     const decorations: sourcegraph.TextDocumentDecoration[] = []
     for (const hunk of hunks) {
         // Hunk start and end lines are 1-indexed, but selection lines are zero-indexed
@@ -29,36 +47,32 @@ export const getBlameDecorations = async ({ uri, settings, selections }: { uri: 
             // Decorate the hunk's start line or, if the hunk's start line is
             // outside of the selection's boundaries, the start line of the selection.
             const decoratedLine = hunkStartLineZeroBased < selection.start.line ? selection.start.line : hunkStartLineZeroBased
-            decorations.push({
-                range: new sourcegraph.Range(decoratedLine, 0, decoratedLine, 0),
-                isWholeLine: true,
-                after: {
-                    light: {
-                        color: 'rgba(0, 0, 25, 0.55)',
-                        backgroundColor: 'rgba(193, 217, 255, 0.65)',
-                    },
-                    dark: {
-                        color: 'rgba(235, 235, 255, 0.55)',
-                        backgroundColor: 'rgba(15, 43, 89, 0.65)',
-                    },
-                    contentText: `${truncate(hunk.author.person.displayName, 25)}, ${formatDistanceStrict(
-                        hunk.author.date,
-                        now,
-                        {
-                            addSuffix: true,
-                        }
-                    )}: • ${truncate(hunk.message, 45)}`,
-                    hoverMessage: `${truncate(hunk.message, 1000)}`,
-                    linkURL: `${
-                        sourcegraph.internal.clientApplication === 'sourcegraph'
-                            ? ''
-                            : sourcegraph.internal.sourcegraphURL
-                    }${hunk.commit.url}`,
-                },
-            })
+            decorations.push(getDecorationFromHunk(hunk, now, decoratedLine))
         }
     }
     return decorations
+}
+
+const getAllBlameDecorations = (hunks: Hunk[], now: number) => hunks.map(hunk => getDecorationFromHunk(hunk, now, hunk.startLine - 1))
+
+
+/**
+ * Queries the blame hunks for the document at the provided URI,
+ * and returns blame decorations for all provided selections,
+ * or for all hunks if `selections` is `null`.
+ *
+ */
+export const getBlameDecorations = async ({ uri, settings, selections }: { uri: string; settings: Settings, selections: sourcegraph.Selection[] | null }): Promise<sourcegraph.TextDocumentDecoration[]> => {
+    if (!settings['git.blame.lineDecorations']) {
+        return []
+    }
+    const hunks = await queryBlameHunks(uri)
+    const now = Date.now()
+    if (selections !== null) {
+        return getBlameDecorationsForSelections(hunks, selections, now)
+    } else {
+        return getAllBlameDecorations(hunks, now)
+    }
 }
 
 interface Hunk {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,15 +11,6 @@ const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.c
 
 export function activate(context: sourcegraph.ExtensionContext): void {
 
-    const selectionChanges = from(sourcegraph.app.activeWindowChanges).pipe(
-        filter((window): window is sourcegraph.Window => window !== undefined),
-        switchMap(window => window.activeViewComponentChanges),
-        filter((editor): editor is sourcegraph.CodeEditor => editor !== undefined),
-        switchMap(editor => from(editor.selectionsChanges).pipe(
-            map(selections => ({ editor, selections }))
-        )),
-    )
-
     // TODO(lguychard) sourcegraph.configuration is currently not rxjs-compatible.
     // Fix this once it has been made compatible.
     const configurationChanges = new BehaviorSubject<void>(undefined)
@@ -27,15 +18,38 @@ export function activate(context: sourcegraph.ExtensionContext): void {
         sourcegraph.configuration.subscribe(() => configurationChanges.next())
     )
 
-    // When the configuration or current file changes, publish new decorations.
-    context.subscriptions.add(
-        combineLatest(configurationChanges, selectionChanges)
-            .subscribe(([, {editor, selections}]) => decorate(editor, selections))
-    )
+    if (sourcegraph.app.activeWindowChanges) {
+        const selectionChanges = from(sourcegraph.app.activeWindowChanges).pipe(
+            filter((window): window is sourcegraph.Window => window !== undefined),
+            switchMap(window => window.activeViewComponentChanges),
+            filter((editor): editor is sourcegraph.CodeEditor => editor !== undefined),
+            switchMap(editor => from(editor.selectionsChanges).pipe(
+                map(selections => ({ editor, selections }))
+            )),
+        )
+        // When the configuration or current file changes, publish new decorations.
+        context.subscriptions.add(
+            combineLatest(configurationChanges, selectionChanges)
+                .subscribe(([, {editor, selections}]) => decorate(editor, selections))
+        )
+    } else {
+        // Backcompat: the extension host does not support activeWindowChanges or CodeEditor.selectionsChanges.
+        // When configuration changes or onDidOpenTextDocument fires, add decorations for all blame hunks.
+        const activeEditor = () => sourcegraph.app.activeWindow && sourcegraph.app.activeWindow.activeViewComponent
+        context.subscriptions.add(
+            combineLatest(configurationChanges, from(sourcegraph.workspace.onDidOpenTextDocument))
+                .subscribe(async () => {
+                    const editor = activeEditor()
+                    if (editor) {
+                        await decorate(editor, null)
+                    }
+                })
+        )
+    }
 
     // TODO: Unpublish decorations on previously (but not currently) open files when settings changes, to avoid a
     // brief flicker of the old state when the file is reopened.
-    async function decorate(editor: sourcegraph.CodeEditor, selections: sourcegraph.Selection[]): Promise<void> {
+    async function decorate(editor: sourcegraph.CodeEditor, selections: sourcegraph.Selection[] | null): Promise<void> {
         const settings = sourcegraph.configuration.get<Settings>().value
         try {
             editor.setDecorations(decorationType, await getBlameDecorations({ uri: editor.document.uri, settings, selections }))


### PR DESCRIPTION
Fixes sourcegraph/sourcegraph#2291

Caused by sourcegraph/sourcegraph#1255

Adds necessary backcompat code to fall back on legacy git blame behaviour (show decorations for all hunks) if the extension host does not implement app.activeWindowChanges, window.activeViewComponentChanges, CodeEditor.selectionsChanges.