### PR TITLE
Action item style: add pressed state

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "title": "${config.git.blame.lineDecorations && \"Hide\" || \"Show\"} blame",
         "actionItem": {
           "label": "Blame",
-          "description": "${config.git.blame.lineDecorations && \"Hide\" || \"Show\"} Git blame line annotations"
+          "description": "${config.git.blame.lineDecorations && \"Hide\" || \"Show\"} Git blame line annotations",
+          "pressed": "config.git.blame.lineDecorations"
         }
       }
     ],


### PR DESCRIPTION
The Sourcegraph git extras extension currently does not have a `pressed` state making it difficult to determine if the extension is activated or not.

This PR adds `pressed` to the action item.