### PR TITLE
feat: commit email in tooltip; display name with Sourcegraph username

### DIFF
--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -62,6 +62,26 @@ const FIXTURE_HUNK_3: Hunk = {
     },
 }
 
+const FIXTURE_HUNK_4: Hunk = {
+    startLine: 4,
+    endLine: 5,
+    author: {
+        person: {
+            email: 'email@email.email',
+            displayName: 'i',
+            user: {
+                username: 'testUserName',
+            },
+        },
+        date: '2018-10-10T21:52:45Z',
+    },
+    rev: 'j',
+    message: 'k',
+    commit: {
+        url: 'l',
+    },
+}
+
 const NOW = +new Date('2018-12-01T21:52:45Z')
 
 const SOURCEGRAPH = createMockSourcegraphAPI()
@@ -131,7 +151,7 @@ describe('getDecorationsFromHunk()', () => {
 describe('getBlameDecorationsForSelections()', () => {
     it('adds decorations only for hunks that are within the selections', () => {
         const decorations = getBlameDecorationsForSelections(
-            [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3],
+            [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
             [new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(1, 0), new SOURCEGRAPH.Position(1, 0)) as any],
             NOW,
             SOURCEGRAPH as any
@@ -141,7 +161,7 @@ describe('getBlameDecorationsForSelections()', () => {
 
     it('handles multiple selections', () => {
         const decorations = getBlameDecorationsForSelections(
-            [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3],
+            [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
             [
                 new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(1, 0), new SOURCEGRAPH.Position(1, 0)) as any,
                 new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(2, 0), new SOURCEGRAPH.Position(5, 0)) as any,
@@ -153,12 +173,13 @@ describe('getBlameDecorationsForSelections()', () => {
         expect(decorations).toEqual([
             getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
             getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
         ])
     })
 
     it('handles multiple hunks per selection', () => {
         const decorations = getBlameDecorationsForSelections(
-            [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3],
+            [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
             [new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(0, 0), new SOURCEGRAPH.Position(5, 0)) as any],
             NOW,
             SOURCEGRAPH as any
@@ -167,6 +188,7 @@ describe('getBlameDecorationsForSelections()', () => {
             getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
             getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
             getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
         ])
     })
 
@@ -190,11 +212,16 @@ describe('getBlameDecorationsForSelections()', () => {
 describe('getAllBlameDecorations()', () => {
     it('adds decorations for all hunks', () => {
         expect(
-            getAllBlameDecorations([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3], NOW, SOURCEGRAPH as any)
+            getAllBlameDecorations(
+                [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
+                NOW,
+                SOURCEGRAPH as any
+            )
         ).toEqual([
             getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
             getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
             getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
         ])
     })
 })
@@ -209,7 +236,7 @@ describe('getBlameDecorations()', () => {
                 },
                 now: NOW,
                 selections: null,
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3]),
+                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([])
@@ -224,13 +251,14 @@ describe('getBlameDecorations()', () => {
                 },
                 now: NOW,
                 selections: null,
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3]),
+                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([
             getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
             getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
             getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
         ])
     })
 
@@ -243,11 +271,24 @@ describe('getBlameDecorations()', () => {
                 },
                 now: NOW,
                 selections: [
-                    new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(2, 0), new SOURCEGRAPH.Position(2, 0)) as any,
+                    new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(3, 0), new SOURCEGRAPH.Position(3, 0)) as any,
                 ],
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3]),
+                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
                 sourcegraph: SOURCEGRAPH as any,
             })
-        ).toEqual([getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any)])
+        ).toEqual([getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any)])
+    })
+
+    it('renders username in decoration content message', async () => {
+        expect(
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any).after!.contentText!.startsWith(
+                `(${FIXTURE_HUNK_4.author.person.user!.username}) ${FIXTURE_HUNK_4.author.person.displayName}`
+            )
+        ).toBe(true)
+        expect(
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any).after!.contentText!.startsWith(
+                `${FIXTURE_HUNK_3.author.person.displayName}`
+            )
+        ).toBe(true)
     })
 })

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -13,7 +13,9 @@ const FIXTURE_HUNK_1: Hunk = {
     endLine: 2,
     author: {
         person: {
+            email: 'email@email.email',
             displayName: 'a',
+            user: null,
         },
         date: '2018-09-10T21:52:45Z',
     },
@@ -29,7 +31,9 @@ const FIXTURE_HUNK_2: Hunk = {
     endLine: 3,
     author: {
         person: {
+            email: 'email@email.email',
             displayName: 'e',
+            user: null,
         },
         date: '2018-11-10T21:52:45Z',
     },
@@ -45,7 +49,9 @@ const FIXTURE_HUNK_3: Hunk = {
     endLine: 4,
     author: {
         person: {
+            email: 'email@email.email',
             displayName: 'i',
+            user: null,
         },
         date: '2018-10-10T21:52:45Z',
     },
@@ -69,7 +75,7 @@ describe('getDecorationsFromHunk()', () => {
                     backgroundColor: 'rgba(15, 43, 89, 0.65)',
                     color: 'rgba(235, 235, 255, 0.55)',
                 },
-                hoverMessage: 'c',
+                hoverMessage: `${FIXTURE_HUNK_1.author.person.email} • ${FIXTURE_HUNK_1.message}`,
                 light: {
                     backgroundColor: 'rgba(193, 217, 255, 0.65)',
                     color: 'rgba(0, 0, 25, 0.55)',
@@ -105,7 +111,9 @@ describe('getDecorationsFromHunk()', () => {
                 ...FIXTURE_HUNK_1,
                 author: {
                     person: {
+                        email: 'email@email.email',
                         displayName: 'asdgjdsag asdklgbasdghladg asdgjlhbasdgjlhabsdg asdgilbadsgiobasgd',
+                        user: null,
                     },
                     date: '2018-09-10T21:52:45Z',
                 },

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -168,4 +168,3 @@ function truncate(s: string, max: number, omission = '…'): string {
     }
     return `${s.slice(0, max)}${omission}`
 }
-

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -149,9 +149,9 @@ export interface Hunk {
         person: {
             email: string
             displayName: string
-            user?: {
+            user: {
                 username: string
-            }
+            } | null
         }
         date: string
     }


### PR DESCRIPTION
Proceeds: [#5690](https://github.com/sourcegraph/sourcegraph/pull/5690)

**Before**

![Screenshot from 2019-09-26 13-48-17](https://user-images.githubusercontent.com/1495145/65689213-72ddca00-e064-11e9-960c-5639ab78b687.png)

**After**

![Screenshot from 2019-09-26 13-48-44](https://user-images.githubusercontent.com/1495145/65689210-72453380-e064-11e9-82e0-6e545e4852cf.png)

