### PR TITLE
feat: add git.blame.decorateWholeFile setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
           "description": "Whether to show Git blame annotations at the end of each line.",
           "type": "boolean",
           "default": false
+        },
+        "git.blame.decorateWholeFile": {
+          "description": "Whether to decorate all lines in a file, rather than just selected lines.",
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -279,6 +279,29 @@ describe('getBlameDecorations()', () => {
         ).toEqual([getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any)])
     })
 
+    it('gets decorations for all hunks if git.blame.decorateWholeFile is true', async () => {
+        expect(
+            await getBlameDecorations({
+                uri: 'a',
+                settings: {
+                    'git.blame.lineDecorations': true,
+                    'git.blame.decorateWholeFile': true,
+                },
+                now: NOW,
+                selections: [
+                    new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(3, 0), new SOURCEGRAPH.Position(3, 0)) as any,
+                ],
+                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                sourcegraph: SOURCEGRAPH as any,
+            })
+        ).toEqual([
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
+        ])
+    })
+
     it('renders username in decoration content message', async () => {
         expect(
             getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any).after!.contentText!.startsWith(

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -135,7 +135,7 @@ export const getBlameDecorations = async ({
         return []
     }
     const hunks = await queryHunks({ uri, sourcegraph })
-    if (selections !== null) {
+    if (selections !== null && !settings['git.blame.decorateWholeFile']) {
         return getBlameDecorationsForSelections(hunks, selections, now, sourcegraph)
     } else {
         return getAllBlameDecorations(hunks, now, sourcegraph)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { getBlameDecorations } from './blame'
 
 export interface Settings {
     ['git.blame.lineDecorations']?: boolean
+    ['git.blame.decorateWholeFile']?: boolean
 }
 
 const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()


### PR DESCRIPTION
Requested by customer https://app.hubspot.com/contacts/2762526/company/554338610

Adds the `git.blame.decorateWholeFile` setting to the extension. If set to `true`, the extension will add decorations for the whole file, rather than just selected lines.