### PR TITLE
feat: support toggling 'whole file' annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sourcegraph/sourcegraph/master/shared/src/schema/extension.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sourcegraph/sourcegraph/main/client/shared/src/schema/extension.schema.json",
   "name": "git-extras",
   "publisher": "sourcegraph",
   "title": "Git extras",
@@ -25,18 +25,17 @@
         "command": "updateConfiguration",
         "commandArguments": [
           [
-            "git.blame.lineDecorations"
+            "git.blame.decorations"
           ],
-          "${!config.git.blame.lineDecorations}",
-          null,
-          "json"
+          "${((!config.git.blame.decorations || config.git.blame.decorations === 'none') && 'line') || (config.git.blame.decorations === 'line' && 'file') || 'none'}",
+          null
         ],
         "category": "Git",
-        "title": "${config.git.blame.lineDecorations && \"Hide\" || \"Show\"} blame",
+        "title": "${((!config.git.blame.decorations || config.git.blame.decorations === 'none') && 'Show blame for selected lines') || (config.git.blame.decorations === 'line' && 'Show blame for the whole file') || 'Hide blame'}",
         "actionItem": {
           "label": "Blame",
-          "description": "${config.git.blame.lineDecorations && \"Hide\" || \"Show\"} Git blame line annotations${!config.git.blame.decorateWholeFile && \" on selected lines\" || \"\"}",
-          "pressed": "config.git.blame.lineDecorations",
+          "description": "${((!config.git.blame.decorations || config.git.blame.decorations === 'none') && 'Show Git blame line annotations on selected lines') || (config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || 'Hide Git blame line annotations'}",
+          "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file') || (config.git.blame.lineDecorations)",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
       }
@@ -67,6 +66,12 @@
           "description": "Whether to decorate all lines in a file, rather than just selected lines.",
           "type": "boolean",
           "default": false
+        },
+        "git.blame.decorations": {
+          "description": "Whether to decorate all lines in a file, only selected lines, or none at all.",
+          "type": "string",
+          "enum": ["none", "line", "file"],
+          "default": "none"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "actionItem": {
           "label": "Blame",
           "description": "${((!config.git.blame.decorations || config.git.blame.decorations === 'none') && 'Show Git blame line annotations on selected lines') || (config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || 'Hide Git blame line annotations'}",
-          "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file') || (config.git.blame.lineDecorations)",
+          "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
       }
@@ -57,16 +57,6 @@
     "configuration": {
       "title": "Git extras",
       "properties": {
-        "git.blame.lineDecorations": {
-          "description": "Whether to show Git blame annotations at the end of each line.",
-          "type": "boolean",
-          "default": false
-        },
-        "git.blame.decorateWholeFile": {
-          "description": "Whether to decorate all lines in a file, rather than just selected lines.",
-          "type": "boolean",
-          "default": false
-        },
         "git.blame.decorations": {
           "description": "Whether to decorate all lines in a file, only selected lines, or none at all.",
           "type": "string",

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -313,43 +313,4 @@ describe('getBlameDecorations()', () => {
             )
         ).toBe(true)
     })
-
-    // Backcompat tests ("git.blame.(lineDecorations|decorateWholeFile)")
-    it('gets no decorations if git.blame.lineDecorations is false', async () => {
-        expect(
-            await getBlameDecorations({
-                uri: 'a',
-                settings: {
-                    'git.blame.lineDecorations': false,
-                },
-                now: NOW,
-                selections: null,
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
-                sourcegraph: SOURCEGRAPH as any,
-            })
-        ).toEqual([])
-    })
-
-    it('gets decorations for all hunks if git.blame.decorateWholeFile is true', async () => {
-        expect(
-            await getBlameDecorations({
-                uri: 'a',
-                settings: {
-                    'git.blame.lineDecorations': true,
-                    'git.blame.decorateWholeFile': true,
-                },
-                now: NOW,
-                selections: [
-                    new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(3, 0), new SOURCEGRAPH.Position(3, 0)) as any,
-                ],
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
-                sourcegraph: SOURCEGRAPH as any,
-            })
-        ).toEqual([
-            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
-        ])
-    })
 })

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -227,27 +227,12 @@ describe('getAllBlameDecorations()', () => {
 })
 
 describe('getBlameDecorations()', () => {
-    it('gets no decorations if git.blame.lineDecorations is false', async () => {
-        expect(
-            await getBlameDecorations({
-                uri: 'a',
-                settings: {
-                    'git.blame.lineDecorations': false,
-                },
-                now: NOW,
-                selections: null,
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
-                sourcegraph: SOURCEGRAPH as any,
-            })
-        ).toEqual([])
-    })
-
     it('gets decorations for all hunks if no selections are passed', async () => {
         expect(
             await getBlameDecorations({
                 uri: 'a',
                 settings: {
-                    'git.blame.lineDecorations': true,
+                    'git.blame.decorations': 'line',
                 },
                 now: NOW,
                 selections: null,
@@ -267,7 +252,7 @@ describe('getBlameDecorations()', () => {
             await getBlameDecorations({
                 uri: 'a',
                 settings: {
-                    'git.blame.lineDecorations': true,
+                    'git.blame.decorations': 'line',
                 },
                 now: NOW,
                 selections: [
@@ -279,13 +264,27 @@ describe('getBlameDecorations()', () => {
         ).toEqual([getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any)])
     })
 
-    it('gets decorations for all hunks if git.blame.decorateWholeFile is true', async () => {
+    it('gets no decorations if git.blame.decorations is "none"', async () => {
         expect(
             await getBlameDecorations({
                 uri: 'a',
                 settings: {
-                    'git.blame.lineDecorations': true,
-                    'git.blame.decorateWholeFile': true,
+                    'git.blame.decorations': 'none',
+                },
+                now: NOW,
+                selections: null,
+                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                sourcegraph: SOURCEGRAPH as any,
+            })
+        ).toEqual([])
+    })
+
+    it('gets decorations for all hunks if git.blame.decorations is "file"', async () => {
+        expect(
+            await getBlameDecorations({
+                uri: 'a',
+                settings: {
+                    'git.blame.decorations': 'file'
                 },
                 now: NOW,
                 selections: [
@@ -313,5 +312,44 @@ describe('getBlameDecorations()', () => {
                 `${FIXTURE_HUNK_3.author.person.displayName}`
             )
         ).toBe(true)
+    })
+
+    // Backcompat tests ("git.blame.(lineDecorations|decorateWholeFile)")
+    it('gets no decorations if git.blame.lineDecorations is false', async () => {
+        expect(
+            await getBlameDecorations({
+                uri: 'a',
+                settings: {
+                    'git.blame.lineDecorations': false,
+                },
+                now: NOW,
+                selections: null,
+                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                sourcegraph: SOURCEGRAPH as any,
+            })
+        ).toEqual([])
+    })
+
+    it('gets decorations for all hunks if git.blame.decorateWholeFile is true', async () => {
+        expect(
+            await getBlameDecorations({
+                uri: 'a',
+                settings: {
+                    'git.blame.lineDecorations': true,
+                    'git.blame.decorateWholeFile': true,
+                },
+                now: NOW,
+                selections: [
+                    new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(3, 0), new SOURCEGRAPH.Position(3, 0)) as any,
+                ],
+                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                sourcegraph: SOURCEGRAPH as any,
+            })
+        ).toEqual([
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
+        ])
     })
 })

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -284,7 +284,7 @@ describe('getBlameDecorations()', () => {
             await getBlameDecorations({
                 uri: 'a',
                 settings: {
-                    'git.blame.decorations': 'file'
+                    'git.blame.decorations': 'file',
                 },
                 now: NOW,
                 selections: [

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -131,10 +131,7 @@ export const getBlameDecorations = async ({
     queryHunks?: ({ uri, sourcegraph }: { uri: string; sourcegraph: typeof import('sourcegraph') }) => Promise<Hunk[]>
     sourcegraph: typeof import('sourcegraph')
 }): Promise<TextDocumentDecoration[]> => {
-    // Backcompat: Check old properties, but "git.blame.decorations" takes precedence over them.
-    const decorations =
-        settings['git.blame.decorations'] ||
-        (settings['git.blame.decorateWholeFile'] ? 'file' : settings['git.blame.lineDecorations'] ? 'line' : 'none')
+    const decorations = settings['git.blame.decorations'] || 'none'
 
     if (decorations === 'none') {
         return []

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -131,11 +131,16 @@ export const getBlameDecorations = async ({
     queryHunks?: ({ uri, sourcegraph }: { uri: string; sourcegraph: typeof import('sourcegraph') }) => Promise<Hunk[]>
     sourcegraph: typeof import('sourcegraph')
 }): Promise<TextDocumentDecoration[]> => {
-    if (!settings['git.blame.lineDecorations']) {
+    // Backcompat: Check old properties, but "git.blame.decorations" takes precedence over them.
+    const decorations =
+        settings['git.blame.decorations'] ||
+        (settings['git.blame.decorateWholeFile'] ? 'file' : settings['git.blame.lineDecorations'] ? 'line' : 'none')
+
+    if (decorations === 'none') {
         return []
     }
     const hunks = await queryHunks({ uri, sourcegraph })
-    if (selections !== null && !settings['git.blame.decorateWholeFile']) {
+    if (selections !== null && decorations === 'line') {
         return getBlameDecorationsForSelections(hunks, selections, now, sourcegraph)
     } else {
         return getAllBlameDecorations(hunks, now, sourcegraph)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,16 +24,16 @@ export function activate(context: sourcegraph.ExtensionContext): void {
     const initialDecorations = settings['git.blame.decorations']
     if (!initialDecorations) {
         if (settings['git.blame.lineDecorations'] === false) {
-            sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'none')
+            sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'none').catch(noop)
         } else if (settings['git.blame.lineDecorations'] === true) {
             if (settings['git.blame.decorateWholeFile']) {
-                sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'file')
+                sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'file').catch(noop)
             } else {
-                sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line')
+                sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line').catch(noop)
             }
         } else {
             // Default to 'line'
-            sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line')
+            sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line').catch(noop)
         }
     }
 
@@ -83,4 +83,8 @@ export function activate(context: sourcegraph.ExtensionContext): void {
             console.error('Decoration error:', err)
         }
     }
+}
+
+function noop(): void {
+    // noop
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,9 @@ export function activate(context: sourcegraph.ExtensionContext): void {
         } catch {
             // noop
         }
-    })()
+    })().catch(() => {
+        // noop
+    })
 
     if (sourcegraph.app.activeWindowChanges) {
         const selectionChanges = from(sourcegraph.app.activeWindowChanges).pipe(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { getBlameDecorations } from './blame'
 export interface Settings {
     ['git.blame.lineDecorations']?: boolean
     ['git.blame.decorateWholeFile']?: boolean
+    ['git.blame.decorations']?: 'none' | 'line' | 'file'
 }
 
 const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,12 +23,17 @@ export function activate(context: sourcegraph.ExtensionContext): void {
     const settings = sourcegraph.configuration.get<Settings>().value
     const initialDecorations = settings['git.blame.decorations']
     if (!initialDecorations) {
-        if (settings['git.blame.lineDecorations']) {
+        if (settings['git.blame.lineDecorations'] === false) {
+            sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'none')
+        } else if (settings['git.blame.lineDecorations'] === true) {
             if (settings['git.blame.decorateWholeFile']) {
                 sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'file')
             } else {
                 sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line')
             }
+        } else {
+            // Default to 'line'
+            sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line')
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,10 +26,14 @@ export function activate(context: sourcegraph.ExtensionContext): void {
             const initialDecorations = settings['git.blame.decorations']
             if (!initialDecorations) {
                 if (settings['git.blame.lineDecorations'] === false) {
-                    sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'none')
+                    await sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'none')
                 } else if (settings['git.blame.lineDecorations'] === true) {
                     if (settings['git.blame.decorateWholeFile']) {
-                        sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'file')
+                        await sourcegraph.commands.executeCommand(
+                            'updateConfiguration',
+                            ['git.blame.decorations'],
+                            'file'
+                        )
                     } else {
                         await sourcegraph.commands.executeCommand(
                             'updateConfiguration',
@@ -39,7 +43,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                     }
                 } else {
                     // Default to 'line'
-                    sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line')
+                    await sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line')
                 }
             }
         } catch {


### PR DESCRIPTION
The toggle action now cycles through 'none' (no annotations), 'line' (annotations only for selected lines) and 'file' (annotations for all lines). 

I tried to make this as backwards compatible as possible, but the first toggle for existing users may be a bit awkward. 