### PR TITLE
fix: remove updateConfiguration command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,40 +19,6 @@ export function activate(context: sourcegraph.ExtensionContext): void {
     const configurationChanges = new BehaviorSubject<void>(undefined)
     context.subscriptions.add(sourcegraph.configuration.subscribe(() => configurationChanges.next(undefined)))
 
-    // Backcompat: Set 'git.blame.decorations' based on previous settings values
-    ;(async () => {
-        try {
-            const settings = sourcegraph.configuration.get<Settings>().value
-            const initialDecorations = settings['git.blame.decorations']
-            if (!initialDecorations) {
-                if (settings['git.blame.lineDecorations'] === false) {
-                    await sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'none')
-                } else if (settings['git.blame.lineDecorations'] === true) {
-                    if (settings['git.blame.decorateWholeFile']) {
-                        await sourcegraph.commands.executeCommand(
-                            'updateConfiguration',
-                            ['git.blame.decorations'],
-                            'file'
-                        )
-                    } else {
-                        await sourcegraph.commands.executeCommand(
-                            'updateConfiguration',
-                            ['git.blame.decorations'],
-                            'line'
-                        )
-                    }
-                } else {
-                    // Default to 'line'
-                    await sourcegraph.commands.executeCommand('updateConfiguration', ['git.blame.decorations'], 'line')
-                }
-            }
-        } catch {
-            // noop
-        }
-    })().catch(() => {
-        // noop
-    })
-
     if (sourcegraph.app.activeWindowChanges) {
         const selectionChanges = from(sourcegraph.app.activeWindowChanges).pipe(
             filter((window): window is Exclude<typeof window, undefined> => window !== undefined),


### PR DESCRIPTION
I'd prefer that users have to toggle one more time than deal with unknown side-effects of updating configuration.