### PR TITLE
fix: compute commit URL for each hunk

### DIFF
--- a/src/blame.ts
+++ b/src/blame.ts
@@ -88,9 +88,6 @@ const queryBlameHunks = memoizeAsync(
                                     }
                                     message
                                     rev
-                                    commit {
-                                        url
-                                    }
                                 }
                             }
                         }
@@ -105,7 +102,10 @@ const queryBlameHunks = memoizeAsync(
         if (!data || !data.repository || !data.repository.commit || !data.repository.commit.blob) {
             throw new Error('no blame data is available (repository, commit, or path not found)')
         }
-        return data.repository.commit.blob.blame
+        return data.repository.commit.blob.blame.map((hunk: Hunk) => {
+            hunk.commit = { url: `/${repo}/-/commit/${hunk.rev}` }
+            return hunk
+        })
     },
     ({ uri }) => uri
 )


### PR DESCRIPTION
This commit makes it so we don't ask the GraphQL API for the commit URL
of each hunk, which can be statically determined based on the repo name
and rev, which are already at hand.

This is part of the mitigation to the spikes of requests we're getting
to gitserver: https://github.com/sourcegraph/sourcegraph/issues/15392