### PR TITLE
feat: show toggle action on code host toolbar for code hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,19 +22,16 @@
     "actions": [
       {
         "id": "git.blame.toggle",
-        "command": "updateConfiguration",
+        "command": "git.blame.toggleDecorations",
         "commandArguments": [
-          [
-            "git.blame.decorations"
-          ],
-          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || 'line'}",
-          null
+          "${config.git.blame.decorations}",
+          "${clientApplication.isSourcegraph}"
         ],
         "category": "Git",
-        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || 'Show blame for selected lines'}",
+        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || (clientApplication.isSourcegraph && 'Show blame for selected lines') || 'Show blame for the whole file'}",
         "actionItem": {
           "label": "Blame",
-          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || 'Show Git blame line annotations on selected lines'}",
+          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || (clientApplication.isSourcegraph && 'Show Git blame line annotations on selected lines') || 'Show Git blame line annotations for the whole file'}",
           "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
@@ -44,7 +41,7 @@
       "editor/title": [
         {
           "action": "git.blame.toggle",
-          "when": "resource && clientApplication.isSourcegraph"
+          "when": "resource"
         }
       ],
       "commandPalette": [


### PR DESCRIPTION
Addresses, but doesn't close, [17430](https://github.com/sourcegraph/sourcegraph/issues/17430)

Users need a way to enable/disable blame decorations on code hosts. We currently only show the "toggle" action item on Sourcegraph.

Problems
- No action item tooltips on GitHub yet, so  part of [16951](https://github.com/sourcegraph/sourcegraph/issues/16951)
- Incomplete selections implementation for code hosts. Decoration setting of `file` is rendered useless.

Temporary solution: Toggle cycles through `none` -> `line` -> `file` on Sourcegraph. On code hosts, toggle between `none` and `file`. 