### PR TITLE
feat: add blame status bar item

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "prettier": "^1.19.1",
     "sinon": "^9.2.1",
     "source-map-support": "^0.5.12",
-    "sourcegraph": "^24.8.0",
+    "sourcegraph": "^25.1.0",
     "ts-node": "^8.10.2",
     "tslint": "^5.11.0",
     "typescript": "^4.1.2",

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -3,6 +3,7 @@ import {
     getAllBlameDecorations,
     getBlameDecorations,
     getBlameDecorationsForSelections,
+    getBlameStatusBarItem,
     getDecorationFromHunk,
     Hunk,
 } from './blame'
@@ -230,13 +231,12 @@ describe('getBlameDecorations()', () => {
     it('gets decorations for all hunks if no selections are passed', async () => {
         expect(
             await getBlameDecorations({
-                uri: 'a',
                 settings: {
                     'git.blame.decorations': 'line',
                 },
                 now: NOW,
                 selections: null,
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([
@@ -250,7 +250,6 @@ describe('getBlameDecorations()', () => {
     it('gets decorations for the selections if selections are passed', async () => {
         expect(
             await getBlameDecorations({
-                uri: 'a',
                 settings: {
                     'git.blame.decorations': 'line',
                 },
@@ -258,7 +257,7 @@ describe('getBlameDecorations()', () => {
                 selections: [
                     new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(3, 0), new SOURCEGRAPH.Position(3, 0)) as any,
                 ],
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any)])
@@ -267,13 +266,12 @@ describe('getBlameDecorations()', () => {
     it('gets no decorations if git.blame.decorations is "none"', async () => {
         expect(
             await getBlameDecorations({
-                uri: 'a',
                 settings: {
                     'git.blame.decorations': 'none',
                 },
                 now: NOW,
                 selections: null,
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([])
@@ -282,7 +280,6 @@ describe('getBlameDecorations()', () => {
     it('gets decorations for all hunks if git.blame.decorations is "file"', async () => {
         expect(
             await getBlameDecorations({
-                uri: 'a',
                 settings: {
                     'git.blame.decorations': 'file',
                 },
@@ -290,7 +287,7 @@ describe('getBlameDecorations()', () => {
                 selections: [
                     new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(3, 0), new SOURCEGRAPH.Position(3, 0)) as any,
                 ],
-                queryHunks: () => Promise.resolve([FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4]),
+                hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([
@@ -312,5 +309,40 @@ describe('getBlameDecorations()', () => {
                 `${FIXTURE_HUNK_3.author.person.displayName}`
             )
         ).toBe(true)
+    })
+})
+
+describe('getBlameStatusBarItem()', () => {
+    it('displays the hunk for the first selected line', () => {
+        expect(
+            getBlameStatusBarItem({
+                selections: [
+                    new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(3, 0), new SOURCEGRAPH.Position(3, 0)) as any,
+                ],
+                hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
+                sourcegraph: SOURCEGRAPH as any,
+                now: NOW,
+            }).text
+        ).toBe('Blame: (testUserName) i, 2 months ago')
+    })
+
+    it('displays the most recent hunk if there are no selections', () => {
+        expect(
+            getBlameStatusBarItem({
+                selections: [],
+                hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
+                sourcegraph: SOURCEGRAPH as any,
+                now: NOW,
+            }).text
+        ).toBe('Blame: e, 21 days ago')
+
+        expect(
+            getBlameStatusBarItem({
+                selections: null,
+                hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
+                sourcegraph: SOURCEGRAPH as any,
+                now: NOW,
+            }).text
+        ).toBe('Blame: e, 21 days ago')
     })
 })

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -230,7 +230,7 @@ describe('getAllBlameDecorations()', () => {
 describe('getBlameDecorations()', () => {
     it('gets decorations for all hunks if no selections are passed', async () => {
         expect(
-            await getBlameDecorations({
+            getBlameDecorations({
                 settings: {
                     'git.blame.decorations': 'line',
                 },
@@ -249,7 +249,7 @@ describe('getBlameDecorations()', () => {
 
     it('gets decorations for the selections if selections are passed', async () => {
         expect(
-            await getBlameDecorations({
+            getBlameDecorations({
                 settings: {
                     'git.blame.decorations': 'line',
                 },
@@ -265,7 +265,7 @@ describe('getBlameDecorations()', () => {
 
     it('gets no decorations if git.blame.decorations is "none"', async () => {
         expect(
-            await getBlameDecorations({
+            getBlameDecorations({
                 settings: {
                     'git.blame.decorations': 'none',
                 },
@@ -279,7 +279,7 @@ describe('getBlameDecorations()', () => {
 
     it('gets decorations for all hunks if git.blame.decorations is "file"', async () => {
         expect(
-            await getBlameDecorations({
+            getBlameDecorations({
                 settings: {
                     'git.blame.decorations': 'file',
                 },

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -1,19 +1,19 @@
+import compareDesc from 'date-fns/compareDesc'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
-import { Selection, TextDocumentDecoration } from 'sourcegraph'
+import { Selection, TextDocumentDecoration, StatusBarItem } from 'sourcegraph'
 import gql from 'tagged-template-noop'
 import { Settings } from './extension'
 import { resolveURI } from './uri'
 import { memoizeAsync } from './util/memoizeAsync'
 
 export const getDecorationFromHunk = (
-    { message, author, commit }: Hunk,
+    hunk: Hunk,
     now: number,
     decoratedLine: number,
     sourcegraph: typeof import('sourcegraph')
 ): TextDocumentDecoration => {
-    const displayName = truncate(author.person.displayName, 25)
-    const username = author.person.user ? `(${author.person.user.username}) ` : ''
-    const distance = formatDistanceStrict(author.date, now, { addSuffix: true })
+    const { displayName, username, distance, linkURL, hoverMessage } = getDisplayInfoFromHunk(hunk, now, sourcegraph)
+
     return {
         range: new sourcegraph.Range(decoratedLine, 0, decoratedLine, 0),
         isWholeLine: true,
@@ -26,9 +26,9 @@ export const getDecorationFromHunk = (
                 color: 'rgba(235, 235, 255, 0.55)',
                 backgroundColor: 'rgba(15, 43, 89, 0.65)',
             },
-            contentText: `${username}${displayName}, ${distance}: • ${truncate(message, 45)}`,
-            hoverMessage: `${author.person.email} • ${truncate(message, 1000)}`,
-            linkURL: new URL(commit.url, sourcegraph.internal.sourcegraphURL.toString()).href,
+            contentText: `${username}${displayName}, ${distance}: • ${truncate(hunk.message, 45)}`,
+            hoverMessage,
+            linkURL: linkURL,
         },
     }
 }
@@ -39,31 +39,15 @@ export const getBlameDecorationsForSelections = (
     now: number,
     sourcegraph: typeof import('sourcegraph')
 ) => {
-    const decorations: TextDocumentDecoration[] = []
-    for (const hunk of hunks) {
-        // Hunk start and end lines are 1-indexed, but selection lines are zero-indexed
-        const hunkStartLineZeroBased = hunk.startLine - 1
-        // A Hunk's end line overlaps with the next hunk's start line.
-        // -2 here to avoid decorating the same line twice.
-        const hunkEndLineZeroBased = hunk.endLine - 2
-        for (const selection of selections) {
-            if (selection.end.line < hunkStartLineZeroBased || selection.start.line > hunkEndLineZeroBased) {
-                continue
-            }
-            // Decorate the hunk's start line or, if the hunk's start line is
-            // outside of the selection's boundaries, the start line of the selection.
-            const decoratedLine =
-                hunkStartLineZeroBased < selection.start.line ? selection.start.line : hunkStartLineZeroBased
-            decorations.push(getDecorationFromHunk(hunk, now, decoratedLine, sourcegraph))
-        }
-    }
-    return decorations
+    return getHunksForSelections(hunks, selections).map(({ hunk, selectionStartLine }) =>
+        getDecorationFromHunk(hunk, now, selectionStartLine, sourcegraph)
+    )
 }
 
 export const getAllBlameDecorations = (hunks: Hunk[], now: number, sourcegraph: typeof import('sourcegraph')) =>
     hunks.map(hunk => getDecorationFromHunk(hunk, now, hunk.startLine - 1, sourcegraph))
 
-const queryBlameHunks = memoizeAsync(
+export const queryBlameHunks = memoizeAsync(
     async ({ uri, sourcegraph }: { uri: string; sourcegraph: typeof import('sourcegraph') }): Promise<Hunk[]> => {
         const { repo, rev, path } = resolveURI(uri)
         const { data, errors } = await sourcegraph.commands.executeCommand(
@@ -111,37 +95,151 @@ const queryBlameHunks = memoizeAsync(
 )
 
 /**
- * Queries the blame hunks for the document at the provided URI,
- * and returns blame decorations for all provided selections,
+ * Returns blame decorations for all provided selections,
  * or for all hunks if `selections` is `null`.
- *
  */
-export const getBlameDecorations = async ({
-    uri,
+export const getBlameDecorations = ({
     settings,
     selections,
     now,
-    queryHunks = queryBlameHunks,
+    hunks,
     sourcegraph,
 }: {
-    uri: string
     settings: Settings
     selections: Selection[] | null
     now: number
-    queryHunks?: ({ uri, sourcegraph }: { uri: string; sourcegraph: typeof import('sourcegraph') }) => Promise<Hunk[]>
+    hunks: Hunk[]
     sourcegraph: typeof import('sourcegraph')
-}): Promise<TextDocumentDecoration[]> => {
+}): TextDocumentDecoration[] => {
     const decorations = settings['git.blame.decorations'] || 'none'
 
     if (decorations === 'none') {
         return []
     }
-    const hunks = await queryHunks({ uri, sourcegraph })
     if (selections !== null && decorations === 'line') {
         return getBlameDecorationsForSelections(hunks, selections, now, sourcegraph)
     } else {
         return getAllBlameDecorations(hunks, now, sourcegraph)
     }
+}
+
+export const getBlameStatusBarItem = ({
+    selections,
+    hunks,
+    now,
+    sourcegraph,
+}: {
+    selections: Selection[] | null
+    hunks: Hunk[]
+    now: number
+    sourcegraph: typeof import('sourcegraph')
+}): StatusBarItem => {
+    if (selections && selections.length > 0) {
+        const hunksForSelections = getHunksForSelections(hunks, selections)
+        if (hunksForSelections[0]) {
+            // Display the commit for the first selected hunk in the status bar.
+            const { displayName, username, distance, linkURL, hoverMessage } = getDisplayInfoFromHunk(
+                hunksForSelections[0].hunk,
+                now,
+                sourcegraph
+            )
+
+            return {
+                text: `Blame: ${username}${displayName}, ${distance}`,
+                command: { id: 'open', args: [linkURL] },
+                tooltip: hoverMessage,
+            }
+        }
+    }
+
+    // Since there are no selections, we want to determine the most
+    // recent change to this file to display in the status bar.
+
+    // Get all hunks
+    const hunksForSelections = getHunksForSelections(hunks, null)
+    const mostRecentHunk = hunksForSelections.sort((a, b) => compareDesc(a.hunk.author.date, b.hunk.author.date))[0]
+    if (!mostRecentHunk) {
+        // Probably a network error
+        return {
+            text: 'Blame: not found',
+        }
+    }
+    const { displayName, username, distance, linkURL, hoverMessage } = getDisplayInfoFromHunk(
+        mostRecentHunk.hunk,
+        now,
+        sourcegraph
+    )
+
+    return {
+        text: `Blame: ${username}${displayName}, ${distance}`,
+        command: { id: 'open', args: [linkURL] },
+        tooltip: hoverMessage,
+    }
+}
+
+/**
+ * Get display info shared between status bar items and text document decorations.
+ */
+const getDisplayInfoFromHunk = (
+    { author, commit, message }: Pick<Hunk, 'author' | 'commit' | 'message'>,
+    now: number,
+    sourcegraph: typeof import('sourcegraph')
+): { displayName: string; username: string; distance: string; linkURL: string; hoverMessage: string } => {
+    const displayName = truncate(author.person.displayName, 25)
+    const username = author.person.user ? `(${author.person.user.username}) ` : ''
+    const distance = formatDistanceStrict(author.date, now, { addSuffix: true })
+    const linkURL = new URL(commit.url, sourcegraph.internal.sourcegraphURL.toString()).href
+    const hoverMessage = `${author.person.email} • ${truncate(message, 1000)}`
+
+    return {
+        displayName,
+        username,
+        distance,
+        linkURL,
+        hoverMessage,
+    }
+}
+
+/**
+ * Get hunks and 0-indexed start lines for the given selections.
+ *
+ * @param selections If null, returns all hunks
+ */
+export const getHunksForSelections = (
+    hunks: Hunk[],
+    selections: Selection[] | null
+): { selectionStartLine: number; hunk: Hunk }[] => {
+    const hunksForSelections: { selectionStartLine: number; hunk: Hunk }[] = []
+
+    if (!selections) {
+        return hunks.map(hunk => ({ hunk, selectionStartLine: hunk.startLine - 1 }))
+    }
+
+    for (const hunk of hunks) {
+        // Hunk start and end lines are 1-indexed, but selection lines are zero-indexed
+        const hunkStartLineZeroBased = hunk.startLine - 1
+        // A Hunk's end line overlaps with the next hunk's start line.
+        // -2 here to avoid decorating the same line twice.
+        const hunkEndLineZeroBased = hunk.endLine - 2
+        for (const selection of selections) {
+            if (selection.end.line < hunkStartLineZeroBased || selection.start.line > hunkEndLineZeroBased) {
+                continue
+            }
+
+            // Decorate the hunk's start line or, if the hunk's start line is
+            // outside of the selection's boundaries, the start line of the selection.
+            const selectionStartLine =
+                hunkStartLineZeroBased < selection.start.line ? selection.start.line : hunkStartLineZeroBased
+            hunksForSelections.push({ selectionStartLine, hunk })
+        }
+    }
+
+    return hunksForSelections
+}
+
+export interface HunkForSelection {
+    hunk: Hunk
+    selectionStartLine: number
 }
 
 export interface Hunk {

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -1,10 +1,70 @@
 import compareDesc from 'date-fns/compareDesc'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
-import { Selection, TextDocumentDecoration, StatusBarItem } from 'sourcegraph'
+import { Selection, StatusBarItem, TextDocumentDecoration } from 'sourcegraph'
 import gql from 'tagged-template-noop'
 import { Settings } from './extension'
 import { resolveURI } from './uri'
 import { memoizeAsync } from './util/memoizeAsync'
+
+/**
+ * Get display info shared between status bar items and text document decorations.
+ */
+const getDisplayInfoFromHunk = (
+    { author, commit, message }: Pick<Hunk, 'author' | 'commit' | 'message'>,
+    now: number,
+    sourcegraph: typeof import('sourcegraph')
+): { displayName: string; username: string; distance: string; linkURL: string; hoverMessage: string } => {
+    const displayName = truncate(author.person.displayName, 25)
+    const username = author.person.user ? `(${author.person.user.username}) ` : ''
+    const distance = formatDistanceStrict(author.date, now, { addSuffix: true })
+    const linkURL = new URL(commit.url, sourcegraph.internal.sourcegraphURL.toString()).href
+    const hoverMessage = `${author.person.email} • ${truncate(message, 1000)}`
+
+    return {
+        displayName,
+        username,
+        distance,
+        linkURL,
+        hoverMessage,
+    }
+}
+
+/**
+ * Get hunks and 0-indexed start lines for the given selections.
+ *
+ * @param selections If null, returns all hunks
+ */
+export const getHunksForSelections = (
+    hunks: Hunk[],
+    selections: Selection[] | null
+): { selectionStartLine: number; hunk: Hunk }[] => {
+    const hunksForSelections: { selectionStartLine: number; hunk: Hunk }[] = []
+
+    if (!selections) {
+        return hunks.map(hunk => ({ hunk, selectionStartLine: hunk.startLine - 1 }))
+    }
+
+    for (const hunk of hunks) {
+        // Hunk start and end lines are 1-indexed, but selection lines are zero-indexed
+        const hunkStartLineZeroBased = hunk.startLine - 1
+        // A Hunk's end line overlaps with the next hunk's start line.
+        // -2 here to avoid decorating the same line twice.
+        const hunkEndLineZeroBased = hunk.endLine - 2
+        for (const selection of selections) {
+            if (selection.end.line < hunkStartLineZeroBased || selection.start.line > hunkEndLineZeroBased) {
+                continue
+            }
+
+            // Decorate the hunk's start line or, if the hunk's start line is
+            // outside of the selection's boundaries, the start line of the selection.
+            const selectionStartLine =
+                hunkStartLineZeroBased < selection.start.line ? selection.start.line : hunkStartLineZeroBased
+            hunksForSelections.push({ selectionStartLine, hunk })
+        }
+    }
+
+    return hunksForSelections
+}
 
 export const getDecorationFromHunk = (
     hunk: Hunk,
@@ -28,7 +88,7 @@ export const getDecorationFromHunk = (
             },
             contentText: `${username}${displayName}, ${distance}: • ${truncate(hunk.message, 45)}`,
             hoverMessage,
-            linkURL: linkURL,
+            linkURL,
         },
     }
 }
@@ -38,11 +98,10 @@ export const getBlameDecorationsForSelections = (
     selections: Selection[],
     now: number,
     sourcegraph: typeof import('sourcegraph')
-) => {
-    return getHunksForSelections(hunks, selections).map(({ hunk, selectionStartLine }) =>
+) =>
+    getHunksForSelections(hunks, selections).map(({ hunk, selectionStartLine }) =>
         getDecorationFromHunk(hunk, now, selectionStartLine, sourcegraph)
     )
-}
 
 export const getAllBlameDecorations = (hunks: Hunk[], now: number, sourcegraph: typeof import('sourcegraph')) =>
     hunks.map(hunk => getDecorationFromHunk(hunk, now, hunk.startLine - 1, sourcegraph))
@@ -175,66 +234,6 @@ export const getBlameStatusBarItem = ({
         command: { id: 'open', args: [linkURL] },
         tooltip: hoverMessage,
     }
-}
-
-/**
- * Get display info shared between status bar items and text document decorations.
- */
-const getDisplayInfoFromHunk = (
-    { author, commit, message }: Pick<Hunk, 'author' | 'commit' | 'message'>,
-    now: number,
-    sourcegraph: typeof import('sourcegraph')
-): { displayName: string; username: string; distance: string; linkURL: string; hoverMessage: string } => {
-    const displayName = truncate(author.person.displayName, 25)
-    const username = author.person.user ? `(${author.person.user.username}) ` : ''
-    const distance = formatDistanceStrict(author.date, now, { addSuffix: true })
-    const linkURL = new URL(commit.url, sourcegraph.internal.sourcegraphURL.toString()).href
-    const hoverMessage = `${author.person.email} • ${truncate(message, 1000)}`
-
-    return {
-        displayName,
-        username,
-        distance,
-        linkURL,
-        hoverMessage,
-    }
-}
-
-/**
- * Get hunks and 0-indexed start lines for the given selections.
- *
- * @param selections If null, returns all hunks
- */
-export const getHunksForSelections = (
-    hunks: Hunk[],
-    selections: Selection[] | null
-): { selectionStartLine: number; hunk: Hunk }[] => {
-    const hunksForSelections: { selectionStartLine: number; hunk: Hunk }[] = []
-
-    if (!selections) {
-        return hunks.map(hunk => ({ hunk, selectionStartLine: hunk.startLine - 1 }))
-    }
-
-    for (const hunk of hunks) {
-        // Hunk start and end lines are 1-indexed, but selection lines are zero-indexed
-        const hunkStartLineZeroBased = hunk.startLine - 1
-        // A Hunk's end line overlaps with the next hunk's start line.
-        // -2 here to avoid decorating the same line twice.
-        const hunkEndLineZeroBased = hunk.endLine - 2
-        for (const selection of selections) {
-            if (selection.end.line < hunkStartLineZeroBased || selection.start.line > hunkEndLineZeroBased) {
-                continue
-            }
-
-            // Decorate the hunk's start line or, if the hunk's start line is
-            // outside of the selection's boundaries, the start line of the selection.
-            const selectionStartLine =
-                hunkStartLineZeroBased < selection.start.line ? selection.start.line : hunkStartLineZeroBased
-            hunksForSelections.push({ selectionStartLine, hunk })
-        }
-    }
-
-    return hunksForSelections
 }
 
 export interface HunkForSelection {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, combineLatest, from } from 'rxjs'
 import { filter, map, switchMap } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
-import { getBlameDecorations, getBlameStatusBarItem, queryBlameHunks, getHunksForSelections } from './blame'
+import { getBlameDecorations, getBlameStatusBarItem, queryBlameHunks } from './blame'
 
 export interface Settings {
     ['git.blame.decorations']?: 'none' | 'line' | 'file'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export interface Settings {
 
 const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()
 
-const statusBarItemType = sourcegraph.app.createStatusBarItemType()
+const statusBarItemType = sourcegraph.app.createStatusBarItemType && sourcegraph.app.createStatusBarItemType()
 
 export function activate(context: sourcegraph.ExtensionContext): void {
     // TODO(lguychard) sourcegraph.configuration is currently not rxjs-compatible.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6340,10 +6340,10 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-sourcegraph@^24.8.0:
-  version "24.8.0"
-  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-24.8.0.tgz#27dc196d8a050ac69f03c3680229d1866f57c754"
-  integrity sha512-uB2SbjEzcA/HWP3Rj+INUXqQweO8HmRdVWW7zesFWZQFBcu7JTcq0pg0jeAN71glKPIyyOgZVrIm1d7KoVzfZw==
+sourcegraph@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-25.1.0.tgz#862202fc8fb61c2957f8bbd6f3674d8dfe3c8966"
+  integrity sha512-B0+ntOilJFopB3FQuRz+SXZLMKeo8y6Aob6yjqtVuC6JRMsKyQ6XwoE842dh65ePOwFvED/kOFLBEcLBJ18jnA==
 
 spawn-wrap@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
#### Description

- Add status bar item that displays blame info for
  - The first selected line
  - The latest commit if no lines are selected
- Refactor to deduplicate common logic between status bar item and text document decorations

#### Screenshot

![Screenshot from 2021-03-25 15-55-20](https://user-images.githubusercontent.com/37420160/112535321-89143580-8d82-11eb-9b13-783740492bf9.png)
