### PR TITLE
Change "Blame:" to "Author:" in status bar for friendlier language

### DIFF
--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -323,7 +323,7 @@ describe('getBlameStatusBarItem()', () => {
                 sourcegraph: SOURCEGRAPH as any,
                 now: NOW,
             }).text
-        ).toBe('Blame: (testUserName) i, 2 months ago')
+        ).toBe('Author: (testUserName) i, 2 months ago')
     })
 
     it('displays the most recent hunk if there are no selections', () => {
@@ -334,7 +334,7 @@ describe('getBlameStatusBarItem()', () => {
                 sourcegraph: SOURCEGRAPH as any,
                 now: NOW,
             }).text
-        ).toBe('Blame: e, 21 days ago')
+        ).toBe('Author: e, 21 days ago')
 
         expect(
             getBlameStatusBarItem({
@@ -343,6 +343,6 @@ describe('getBlameStatusBarItem()', () => {
                 sourcegraph: SOURCEGRAPH as any,
                 now: NOW,
             }).text
-        ).toBe('Blame: e, 21 days ago')
+        ).toBe('Author: e, 21 days ago')
     })
 })

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -204,7 +204,7 @@ export const getBlameStatusBarItem = ({
             )
 
             return {
-                text: `Blame: ${username}${displayName}, ${distance}`,
+                text: `Author: ${username}${displayName}, ${distance}`,
                 command: { id: 'open', args: [linkURL] },
                 tooltip: hoverMessage,
             }
@@ -220,7 +220,7 @@ export const getBlameStatusBarItem = ({
     if (!mostRecentHunk) {
         // Probably a network error
         return {
-            text: 'Blame: not found',
+            text: 'Author: not found',
         }
     }
     const { displayName, username, distance, linkURL, hoverMessage } = getDisplayInfoFromHunk(
@@ -230,7 +230,7 @@ export const getBlameStatusBarItem = ({
     )
 
     return {
-        text: `Blame: ${username}${displayName}, ${distance}`,
+        text: `Author: ${username}${displayName}, ${distance}`,
         command: { id: 'open', args: [linkURL] },
         tooltip: hoverMessage,
     }


### PR DESCRIPTION
This is always shown in the status bar, which comes with a negative connotation for any code that is being viewed (as someone is to be blamed for it). It's more neutral to state that this is the "author" of the code, without implying they are to be "blamed" for anything (even if the underlying Git CLI command is called `git blame`).