### PR TITLE
feat: add showPreciseDate setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
           "type": "string",
           "enum": ["none", "line", "file"],
           "default": "none"
+        },
+        "git.blame.showPreciseDate": {
+          "description": "Whether to show precise dates (e.g. \"Mar 17, 2021\"). By default, distance from current date is shown (e.g. \"3 months ago\")",
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -89,7 +89,9 @@ const SOURCEGRAPH = createMockSourcegraphAPI()
 
 describe('getDecorationsFromHunk()', () => {
     it('creates a TextDocumentDecoration from a Hunk', () => {
-        expect(getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any)).toEqual({
+        expect(
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any)
+        ).toEqual({
             after: {
                 contentText: 'a, 3 months ago: • c',
                 dark: {
@@ -119,6 +121,7 @@ describe('getDecorationsFromHunk()', () => {
             },
             NOW,
             0,
+            { 'git.blame.showPreciseDate': false },
             SOURCEGRAPH as any
         )
         expect(decoration.after && decoration.after.contentText).toEqual(
@@ -141,6 +144,7 @@ describe('getDecorationsFromHunk()', () => {
             },
             NOW,
             0,
+            { 'git.blame.showPreciseDate': false },
             SOURCEGRAPH as any
         )
         expect(decoration.after && decoration.after.contentText).toEqual(
@@ -155,9 +159,12 @@ describe('getBlameDecorationsForSelections()', () => {
             [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
             [new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(1, 0), new SOURCEGRAPH.Position(1, 0)) as any],
             NOW,
+            { 'git.blame.showPreciseDate': false },
             SOURCEGRAPH as any
         )
-        expect(decorations).toEqual([getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any)])
+        expect(decorations).toEqual([
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+        ])
     })
 
     it('handles multiple selections', () => {
@@ -169,12 +176,13 @@ describe('getBlameDecorationsForSelections()', () => {
                 new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(6, 0), new SOURCEGRAPH.Position(10, 0)) as any,
             ],
             NOW,
+            { 'git.blame.showPreciseDate': false },
             SOURCEGRAPH as any
         )
         expect(decorations).toEqual([
-            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
         ])
     })
 
@@ -183,13 +191,14 @@ describe('getBlameDecorationsForSelections()', () => {
             [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
             [new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(0, 0), new SOURCEGRAPH.Position(5, 0)) as any],
             NOW,
+            { 'git.blame.showPreciseDate': false },
             SOURCEGRAPH as any
         )
         expect(decorations).toEqual([
-            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
         ])
     })
 
@@ -204,9 +213,12 @@ describe('getBlameDecorationsForSelections()', () => {
             ],
             [new SOURCEGRAPH.Selection(new SOURCEGRAPH.Position(2, 0), new SOURCEGRAPH.Position(2, 0)) as any],
             NOW,
+            { 'git.blame.showPreciseDate': false },
             SOURCEGRAPH as any
         )
-        expect(decorations).toEqual([getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 2, SOURCEGRAPH as any)])
+        expect(decorations).toEqual([
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 2, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+        ])
     })
 })
 
@@ -216,13 +228,14 @@ describe('getAllBlameDecorations()', () => {
             getAllBlameDecorations(
                 [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 NOW,
+                { 'git.blame.showPreciseDate': false },
                 SOURCEGRAPH as any
             )
         ).toEqual([
-            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
         ])
     })
 })
@@ -233,6 +246,7 @@ describe('getBlameDecorations()', () => {
             getBlameDecorations({
                 settings: {
                     'git.blame.decorations': 'line',
+                    'git.blame.showPreciseDate': false,
                 },
                 now: NOW,
                 selections: null,
@@ -240,10 +254,10 @@ describe('getBlameDecorations()', () => {
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([
-            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
         ])
     })
 
@@ -260,7 +274,9 @@ describe('getBlameDecorations()', () => {
                 hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
             })
-        ).toEqual([getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any)])
+        ).toEqual([
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+        ])
     })
 
     it('gets no decorations if git.blame.decorations is "none"', async () => {
@@ -291,23 +307,33 @@ describe('getBlameDecorations()', () => {
                 sourcegraph: SOURCEGRAPH as any,
             })
         ).toEqual([
-            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any),
-            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_2, NOW, 1, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
+            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any),
         ])
     })
 
     it('renders username in decoration content message', async () => {
         expect(
-            getDecorationFromHunk(FIXTURE_HUNK_4, NOW, 3, SOURCEGRAPH as any).after!.contentText!.startsWith(
+            getDecorationFromHunk(
+                FIXTURE_HUNK_4,
+                NOW,
+                3,
+                { 'git.blame.showPreciseDate': false },
+                SOURCEGRAPH as any
+            ).after!.contentText!.startsWith(
                 `(${FIXTURE_HUNK_4.author.person.user!.username}) ${FIXTURE_HUNK_4.author.person.displayName}`
             )
         ).toBe(true)
         expect(
-            getDecorationFromHunk(FIXTURE_HUNK_3, NOW, 2, SOURCEGRAPH as any).after!.contentText!.startsWith(
-                `${FIXTURE_HUNK_3.author.person.displayName}`
-            )
+            getDecorationFromHunk(
+                FIXTURE_HUNK_3,
+                NOW,
+                2,
+                { 'git.blame.showPreciseDate': false },
+                SOURCEGRAPH as any
+            ).after!.contentText!.startsWith(`${FIXTURE_HUNK_3.author.person.displayName}`)
         ).toBe(true)
     })
 })
@@ -321,6 +347,7 @@ describe('getBlameStatusBarItem()', () => {
                 ],
                 hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
+                settings: { 'git.blame.showPreciseDate': false },
                 now: NOW,
             }).text
         ).toBe('Author: (testUserName) i, 2 months ago')
@@ -332,6 +359,7 @@ describe('getBlameStatusBarItem()', () => {
                 selections: [],
                 hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
+                settings: { 'git.blame.showPreciseDate': false },
                 now: NOW,
             }).text
         ).toBe('Author: e, 21 days ago')
@@ -341,6 +369,7 @@ describe('getBlameStatusBarItem()', () => {
                 selections: null,
                 hunks: [FIXTURE_HUNK_1, FIXTURE_HUNK_2, FIXTURE_HUNK_3, FIXTURE_HUNK_4],
                 sourcegraph: SOURCEGRAPH as any,
+                settings: { 'git.blame.showPreciseDate': false },
                 now: NOW,
             }).text
         ).toBe('Author: e, 21 days ago')

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -10,12 +10,17 @@ import { memoizeAsync } from './util/memoizeAsync'
 /**
  * Get display info shared between status bar items and text document decorations.
  */
-const getDisplayInfoFromHunk = (
-    { author, commit, message }: Pick<Hunk, 'author' | 'commit' | 'message'>,
-    now: number,
-    settings: Pick<Settings, 'git.blame.showPreciseDate'>,
+const getDisplayInfoFromHunk = ({
+    hunk: { author, commit, message },
+    now,
+    settings,
+    sourcegraph,
+}: {
+    hunk: Pick<Hunk, 'author' | 'commit' | 'message'>
+    now: number
+    settings: Pick<Settings, 'git.blame.showPreciseDate'>
     sourcegraph: typeof import('sourcegraph')
-): { displayName: string; username: string; dateString: string; linkURL: string; hoverMessage: string } => {
+}): { displayName: string; username: string; dateString: string; linkURL: string; hoverMessage: string } => {
     const displayName = truncate(author.person.displayName, 25)
     const username = author.person.user ? `(${author.person.user.username}) ` : ''
     const dateString = settings['git.blame.showPreciseDate']
@@ -77,12 +82,12 @@ export const getDecorationFromHunk = (
     settings: Pick<Settings, 'git.blame.showPreciseDate'>,
     sourcegraph: typeof import('sourcegraph')
 ): TextDocumentDecoration => {
-    const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk(
+    const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk({
         hunk,
         now,
         settings,
-        sourcegraph
-    )
+        sourcegraph,
+    })
 
     return {
         range: new sourcegraph.Range(decoratedLine, 0, decoratedLine, 0),
@@ -214,12 +219,12 @@ export const getBlameStatusBarItem = ({
         const hunksForSelections = getHunksForSelections(hunks, selections)
         if (hunksForSelections[0]) {
             // Display the commit for the first selected hunk in the status bar.
-            const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk(
-                hunksForSelections[0].hunk,
+            const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk({
+                hunk: hunksForSelections[0].hunk,
                 now,
                 settings,
-                sourcegraph
-            )
+                sourcegraph,
+            })
 
             return {
                 text: `Author: ${username}${displayName}, ${dateString}`,
@@ -241,12 +246,12 @@ export const getBlameStatusBarItem = ({
             text: 'Author: not found',
         }
     }
-    const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk(
-        mostRecentHunk.hunk,
+    const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk({
+        hunk: mostRecentHunk.hunk,
         now,
         settings,
-        sourcegraph
-    )
+        sourcegraph,
+    })
 
     return {
         text: `Author: ${username}${displayName}, ${dateString}`,

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -1,4 +1,5 @@
 import compareDesc from 'date-fns/compareDesc'
+import format from 'date-fns/format'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import { Selection, StatusBarItem, TextDocumentDecoration } from 'sourcegraph'
 import gql from 'tagged-template-noop'
@@ -12,18 +13,21 @@ import { memoizeAsync } from './util/memoizeAsync'
 const getDisplayInfoFromHunk = (
     { author, commit, message }: Pick<Hunk, 'author' | 'commit' | 'message'>,
     now: number,
+    settings: Pick<Settings, 'git.blame.showPreciseDate'>,
     sourcegraph: typeof import('sourcegraph')
-): { displayName: string; username: string; distance: string; linkURL: string; hoverMessage: string } => {
+): { displayName: string; username: string; dateString: string; linkURL: string; hoverMessage: string } => {
     const displayName = truncate(author.person.displayName, 25)
     const username = author.person.user ? `(${author.person.user.username}) ` : ''
-    const distance = formatDistanceStrict(author.date, now, { addSuffix: true })
+    const dateString = settings['git.blame.showPreciseDate']
+        ? format(author.date, 'MMM dd, y')
+        : formatDistanceStrict(author.date, now, { addSuffix: true })
     const linkURL = new URL(commit.url, sourcegraph.internal.sourcegraphURL.toString()).href
     const hoverMessage = `${author.person.email} • ${truncate(message, 1000)}`
 
     return {
         displayName,
         username,
-        distance,
+        dateString,
         linkURL,
         hoverMessage,
     }
@@ -70,9 +74,15 @@ export const getDecorationFromHunk = (
     hunk: Hunk,
     now: number,
     decoratedLine: number,
+    settings: Pick<Settings, 'git.blame.showPreciseDate'>,
     sourcegraph: typeof import('sourcegraph')
 ): TextDocumentDecoration => {
-    const { displayName, username, distance, linkURL, hoverMessage } = getDisplayInfoFromHunk(hunk, now, sourcegraph)
+    const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk(
+        hunk,
+        now,
+        settings,
+        sourcegraph
+    )
 
     return {
         range: new sourcegraph.Range(decoratedLine, 0, decoratedLine, 0),
@@ -86,7 +96,7 @@ export const getDecorationFromHunk = (
                 color: 'rgba(235, 235, 255, 0.55)',
                 backgroundColor: 'rgba(15, 43, 89, 0.65)',
             },
-            contentText: `${username}${displayName}, ${distance}: • ${truncate(hunk.message, 45)}`,
+            contentText: `${username}${displayName}, ${dateString}: • ${truncate(hunk.message, 45)}`,
             hoverMessage,
             linkURL,
         },
@@ -97,14 +107,19 @@ export const getBlameDecorationsForSelections = (
     hunks: Hunk[],
     selections: Selection[],
     now: number,
+    settings: Pick<Settings, 'git.blame.showPreciseDate'>,
     sourcegraph: typeof import('sourcegraph')
 ) =>
     getHunksForSelections(hunks, selections).map(({ hunk, selectionStartLine }) =>
-        getDecorationFromHunk(hunk, now, selectionStartLine, sourcegraph)
+        getDecorationFromHunk(hunk, now, selectionStartLine, settings, sourcegraph)
     )
 
-export const getAllBlameDecorations = (hunks: Hunk[], now: number, sourcegraph: typeof import('sourcegraph')) =>
-    hunks.map(hunk => getDecorationFromHunk(hunk, now, hunk.startLine - 1, sourcegraph))
+export const getAllBlameDecorations = (
+    hunks: Hunk[],
+    now: number,
+    settings: Pick<Settings, 'git.blame.showPreciseDate'>,
+    sourcegraph: typeof import('sourcegraph')
+) => hunks.map(hunk => getDecorationFromHunk(hunk, now, hunk.startLine - 1, settings, sourcegraph))
 
 export const queryBlameHunks = memoizeAsync(
     async ({ uri, sourcegraph }: { uri: string; sourcegraph: typeof import('sourcegraph') }): Promise<Hunk[]> => {
@@ -176,9 +191,9 @@ export const getBlameDecorations = ({
         return []
     }
     if (selections !== null && decorations === 'line') {
-        return getBlameDecorationsForSelections(hunks, selections, now, sourcegraph)
+        return getBlameDecorationsForSelections(hunks, selections, now, settings, sourcegraph)
     } else {
-        return getAllBlameDecorations(hunks, now, sourcegraph)
+        return getAllBlameDecorations(hunks, now, settings, sourcegraph)
     }
 }
 
@@ -186,25 +201,28 @@ export const getBlameStatusBarItem = ({
     selections,
     hunks,
     now,
+    settings,
     sourcegraph,
 }: {
     selections: Selection[] | null
     hunks: Hunk[]
     now: number
+    settings: Pick<Settings, 'git.blame.showPreciseDate'>
     sourcegraph: typeof import('sourcegraph')
 }): StatusBarItem => {
     if (selections && selections.length > 0) {
         const hunksForSelections = getHunksForSelections(hunks, selections)
         if (hunksForSelections[0]) {
             // Display the commit for the first selected hunk in the status bar.
-            const { displayName, username, distance, linkURL, hoverMessage } = getDisplayInfoFromHunk(
+            const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk(
                 hunksForSelections[0].hunk,
                 now,
+                settings,
                 sourcegraph
             )
 
             return {
-                text: `Author: ${username}${displayName}, ${distance}`,
+                text: `Author: ${username}${displayName}, ${dateString}`,
                 command: { id: 'open', args: [linkURL] },
                 tooltip: hoverMessage,
             }
@@ -223,14 +241,15 @@ export const getBlameStatusBarItem = ({
             text: 'Author: not found',
         }
     }
-    const { displayName, username, distance, linkURL, hoverMessage } = getDisplayInfoFromHunk(
+    const { displayName, username, dateString, linkURL, hoverMessage } = getDisplayInfoFromHunk(
         mostRecentHunk.hunk,
         now,
+        settings,
         sourcegraph
     )
 
     return {
-        text: `Author: ${username}${displayName}, ${distance}`,
+        text: `Author: ${username}${displayName}, ${dateString}`,
         command: { id: 'open', args: [linkURL] },
         tooltip: hoverMessage,
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ export interface Settings {
     // to 'onboard' users to new setting
     ['git.blame.lineDecorations']?: boolean
     ['git.blame.decorateWholeFile']?: boolean
+    ['git.blame.showPreciseDate']?: boolean
 }
 
 const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()
@@ -61,7 +62,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
             if ('setStatusBarItem' in editor) {
                 editor.setStatusBarItem(
                     statusBarItemType,
-                    getBlameStatusBarItem({ selections, hunks, now, sourcegraph })
+                    getBlameStatusBarItem({ selections, hunks, now, settings, sourcegraph })
                 )
             }
 


### PR DESCRIPTION
When set `git.blame.showPreciseDate` is `true` in user settings, all dates displayed by this extension will be absolute (as opposed to relative by default).

![Screenshot from 2021-08-02 15-01-46](https://user-images.githubusercontent.com/37420160/127910884-21f55d08-304f-4d11-9f71-e41ddd4fb3ae.png)
