### PR TITLE
feat: vary blame modes depending on `enableExtensionsDecorationsColumnView` experimental feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "prettier": "^1.19.1",
     "sinon": "^9.2.1",
     "source-map-support": "^0.5.12",
-    "sourcegraph": "^25.3.0",
+    "sourcegraph": "^25.6.0",
     "ts-node": "^8.10.2",
     "tslint": "^5.11.0",
     "typescript": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
           [
             "git.blame.decorations"
           ],
-          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || 'line'}",
+          "${((config.git.blame.decorations === 'file' && 'none') || 'file')}",
           null
         ],
         "category": "Git",
-        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || 'Show blame for selected lines'}",
+        "title": "${((config.git.blame.decorations === 'none' && 'Show blame for the whole file') || 'Hide blame')}",
         "actionItem": {
           "label": "Blame",
-          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || 'Show Git blame line annotations on selected lines'}",
-          "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
+          "description": "${((config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || 'Show Git blame line annotations for the whole file')}",
+          "pressed": "(config.git.blame.decorations === 'file')",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
       }
@@ -58,9 +58,9 @@
       "title": "Git extras",
       "properties": {
         "git.blame.decorations": {
-          "description": "Whether to decorate all lines in a file, only selected lines, or none at all.",
+          "description": "Whether to decorate all lines in a file, or none at all.",
           "type": "string",
-          "enum": ["none", "line", "file"],
+          "enum": ["none", "file"],
           "default": "none"
         },
         "git.blame.showPreciseDate": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@types/node": "16.11.26",
     "@types/sinon": "10.0.11",
     "expect": "^24.1.0",
+    "graphql": "^15.4.0",
     "husky": "^4.3.5",
     "lnfs-cli": "^2.1.0",
     "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
           [
             "git.blame.decorations"
           ],
-          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || 'line'}",
+          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || (clientApplication.isSourcegraph && experimentalFeatures.showGitBlameInSeparateColumn && 'file' || 'line')}",
           null
         ],
         "category": "Git",
-        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || 'Show blame for selected lines'}",
+        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || (clientApplication.isSourcegraph && experimentalFeatures.showGitBlameInSeparateColumn && 'Show blame for the whole file' || 'Show blame for selected lines')}",
         "actionItem": {
           "label": "Blame",
-          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || 'Show Git blame line annotations on selected lines'}",
-          "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
+          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || (clientApplication.isSourcegraph && experimentalFeatures.showGitBlameInSeparateColumn && 'Show Git blame line annotations for the whole file' || 'Show Git blame line annotations on selected lines')}",
+          "pressed": "((!clientApplication.isSourcegraph || !experimentalFeatures.showGitBlameInSeparateColumn) && config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
           [
             "git.blame.decorations"
           ],
-          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || (clientApplication.isSourcegraph && experimentalFeatures.showGitBlameInSeparateColumn && 'file' || 'line')}",
+          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || (clientApplication.isSourcegraph && experimentalFeatures.enableExtensionsDecorationsColumnView && 'file' || 'line')}",
           null
         ],
         "category": "Git",
-        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || (clientApplication.isSourcegraph && experimentalFeatures.showGitBlameInSeparateColumn && 'Show blame for the whole file' || 'Show blame for selected lines')}",
+        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || (clientApplication.isSourcegraph && experimentalFeatures.enableExtensionsDecorationsColumnView && 'Show blame for the whole file' || 'Show blame for selected lines')}",
         "actionItem": {
           "label": "Blame",
-          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || (clientApplication.isSourcegraph && experimentalFeatures.showGitBlameInSeparateColumn && 'Show Git blame line annotations for the whole file' || 'Show Git blame line annotations on selected lines')}",
-          "pressed": "((!clientApplication.isSourcegraph || !experimentalFeatures.showGitBlameInSeparateColumn) && config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
+          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || (clientApplication.isSourcegraph && experimentalFeatures.enableExtensionsDecorationsColumnView && 'Show Git blame line annotations for the whole file' || 'Show Git blame line annotations on selected lines')}",
+          "pressed": "((!clientApplication.isSourcegraph || !experimentalFeatures.enableExtensionsDecorationsColumnView) && config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
           [
             "git.blame.decorations"
           ],
-          "${((config.git.blame.decorations === 'file' && 'none') || 'file')}",
+          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || 'line'}",
           null
         ],
         "category": "Git",
-        "title": "${((config.git.blame.decorations === 'none' && 'Show blame for the whole file') || 'Hide blame')}",
+        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || 'Show blame for selected lines'}",
         "actionItem": {
           "label": "Blame",
-          "description": "${((config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || 'Show Git blame line annotations for the whole file')}",
-          "pressed": "(config.git.blame.decorations === 'file')",
+          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || 'Show Git blame line annotations on selected lines'}",
+          "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
       }
@@ -58,9 +58,9 @@
       "title": "Git extras",
       "properties": {
         "git.blame.decorations": {
-          "description": "Whether to decorate all lines in a file, or none at all.",
+          "description": "Whether to decorate all lines in a file, only selected lines, or none at all.",
           "type": "string",
-          "enum": ["none", "file"],
+          "enum": ["none", "line", "file"],
           "default": "none"
         },
         "git.blame.showPreciseDate": {

--- a/src/blame.test.ts
+++ b/src/blame.test.ts
@@ -93,7 +93,7 @@ describe('getDecorationsFromHunk()', () => {
             getDecorationFromHunk(FIXTURE_HUNK_1, NOW, 0, { 'git.blame.showPreciseDate': false }, SOURCEGRAPH as any)
         ).toEqual({
             after: {
-                contentText: 'a, 3 months ago: • c',
+                contentText: '3 months ago • a [c]',
                 dark: {
                     backgroundColor: 'rgba(15, 43, 89, 0.65)',
                     color: 'rgba(235, 235, 255, 0.55)',
@@ -125,7 +125,7 @@ describe('getDecorationsFromHunk()', () => {
             SOURCEGRAPH as any
         )
         expect(decoration.after && decoration.after.contentText).toEqual(
-            'a, 3 months ago: • asdgjdsag asdklgbasdghladg asdgjlhbasdgjlhabs…'
+            '3 months ago • a [asdgjdsag asdklgbasdghladg asdgjlhbasdgjlhabs…]'
         )
     })
 
@@ -148,7 +148,7 @@ describe('getDecorationsFromHunk()', () => {
             SOURCEGRAPH as any
         )
         expect(decoration.after && decoration.after.contentText).toEqual(
-            'asdgjdsag asdklgbasdghlad…, 3 months ago: • c'
+            '3 months ago • asdgjdsag asdklgbasdghlad… [c]'
         )
     })
 })
@@ -322,7 +322,7 @@ describe('getBlameDecorations()', () => {
                 3,
                 { 'git.blame.showPreciseDate': false },
                 SOURCEGRAPH as any
-            ).after!.contentText!.startsWith(
+            ).after!.contentText!.includes(
                 `(${FIXTURE_HUNK_4.author.person.user!.username}) ${FIXTURE_HUNK_4.author.person.displayName}`
             )
         ).toBe(true)
@@ -333,7 +333,7 @@ describe('getBlameDecorations()', () => {
                 2,
                 { 'git.blame.showPreciseDate': false },
                 SOURCEGRAPH as any
-            ).after!.contentText!.startsWith(`${FIXTURE_HUNK_3.author.person.displayName}`)
+            ).after!.contentText!.includes(`${FIXTURE_HUNK_3.author.person.displayName}`)
         ).toBe(true)
     })
 })

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -99,7 +99,7 @@ export const getDecorationFromHunk = (
             dark: {
                 color: 'rgba(235, 235, 255, 0.55)',
             },
-            contentText: `${username}${displayName}, ${dateString}: • ${truncate(hunk.message, 45)}`,
+            contentText: `${dateString} ${username}${displayName} [${truncate(hunk.message, 45)}]`,
             hoverMessage,
             linkURL,
         },

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -95,27 +95,18 @@ export const getDecorationFromHunk = (
         after: {
             light: {
                 color: 'rgba(0, 0, 25, 0.55)',
+                backgroundColor: 'rgba(193, 217, 255, 0.65)',
             },
             dark: {
                 color: 'rgba(235, 235, 255, 0.55)',
+                backgroundColor: 'rgba(15, 43, 89, 0.65)',
             },
-            contentText: `${dateString} ${username}${displayName} [${truncate(hunk.message, 45)}]`,
+            contentText: `${dateString} • ${username}${displayName} [${truncate(hunk.message, 45)}]`,
             hoverMessage,
             linkURL,
         },
     }
 }
-
-export const getBlameDecorationsForSelections = (
-    hunks: Hunk[],
-    selections: Selection[],
-    now: number,
-    settings: Pick<Settings, 'git.blame.showPreciseDate'>,
-    sourcegraph: typeof import('sourcegraph')
-) =>
-    getHunksForSelections(hunks, selections).map(({ hunk, selectionStartLine }) =>
-        getDecorationFromHunk(hunk, now, selectionStartLine, settings, sourcegraph)
-    )
 
 export const getAllBlameDecorations = (
     hunks: Hunk[],
@@ -177,28 +168,16 @@ export const queryBlameHunks = memoizeAsync(
  */
 export const getBlameDecorations = ({
     settings,
-    selections,
     now,
     hunks,
     sourcegraph,
 }: {
     settings: Settings
-    selections: Selection[] | null
     now: number
     hunks: Hunk[]
     sourcegraph: typeof import('sourcegraph')
-}): TextDocumentDecoration[] => {
-    const decorations = settings['git.blame.decorations'] || 'none'
-
-    if (decorations === 'none') {
-        return []
-    }
-    if (selections !== null && decorations === 'line') {
-        return getBlameDecorationsForSelections(hunks, selections, now, settings, sourcegraph)
-    } else {
-        return getAllBlameDecorations(hunks, now, settings, sourcegraph)
-    }
-}
+}): TextDocumentDecoration[] =>
+    settings['git.blame.decorations'] === 'file' ? getAllBlameDecorations(hunks, now, settings, sourcegraph) : []
 
 export const getBlameStatusBarItem = ({
     selections,

--- a/src/blame.ts
+++ b/src/blame.ts
@@ -95,11 +95,9 @@ export const getDecorationFromHunk = (
         after: {
             light: {
                 color: 'rgba(0, 0, 25, 0.55)',
-                backgroundColor: 'rgba(193, 217, 255, 0.65)',
             },
             dark: {
                 color: 'rgba(235, 235, 255, 0.55)',
-                backgroundColor: 'rgba(15, 43, 89, 0.65)',
             },
             contentText: `${username}${displayName}, ${dateString}: • ${truncate(hunk.message, 45)}`,
             hoverMessage,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as sourcegraph from 'sourcegraph'
 import { getBlameDecorations, getBlameStatusBarItem, queryBlameHunks } from './blame'
 
 export interface Settings {
-    ['git.blame.decorations']?: 'none' | 'line' | 'file'
+    ['git.blame.decorations']?: 'none' | 'file'
     // The following two settings are deprecated, but we will still look for them
     // to 'onboard' users to new setting
     ['git.blame.lineDecorations']?: boolean

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as sourcegraph from 'sourcegraph'
 import { getBlameDecorations, getBlameStatusBarItem, queryBlameHunks } from './blame'
 
 export interface Settings {
-    ['git.blame.decorations']?: 'none' | 'file'
+    ['git.blame.decorations']?: 'none' | 'line' | 'file'
     // The following two settings are deprecated, but we will still look for them
     // to 'onboard' users to new setting
     ['git.blame.lineDecorations']?: boolean
@@ -66,7 +66,16 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                 )
             }
 
-            editor.setDecorations(decorationType, getBlameDecorations({ hunks, now, settings, sourcegraph }))
+            editor.setDecorations(
+                decorationType,
+                getBlameDecorations({
+                    hunks,
+                    now,
+                    settings,
+                    selections,
+                    sourcegraph,
+                })
+            )
         } catch (err) {
             console.error('Decoration/status bar error:', err)
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,16 +66,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                 )
             }
 
-            editor.setDecorations(
-                decorationType,
-                getBlameDecorations({
-                    hunks,
-                    now,
-                    settings,
-                    selections,
-                    sourcegraph,
-                })
-            )
+            editor.setDecorations(decorationType, getBlameDecorations({ hunks, now, settings, sourcegraph }))
         } catch (err) {
             console.error('Decoration/status bar error:', err)
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,15 @@ export interface Settings {
     ['git.blame.lineDecorations']?: boolean
     ['git.blame.decorateWholeFile']?: boolean
     ['git.blame.showPreciseDate']?: boolean
+
+    experimentalFeatures?: {
+        showGitBlameInSeparateColumn?: boolean
+    }
 }
+
+const isBlameForSelectedLinesEnabled = () =>
+    !sourcegraph.configuration.get<Settings>().get('experimentalFeatures')?.showGitBlameInSeparateColumn ||
+    sourcegraph.internal.clientApplication !== 'sourcegraph'
 
 const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()
 
@@ -32,7 +40,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
         // When the configuration or current file changes, publish new decorations.
         context.subscriptions.add(
             combineLatest(configurationChanges, selectionChanges).subscribe(([, { editor, selections }]) =>
-                decorate(editor, selections)
+                decorate(editor, isBlameForSelectedLinesEnabled() ? selections : null)
             )
         )
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,15 +12,16 @@ export interface Settings {
     ['git.blame.showPreciseDate']?: boolean
 
     experimentalFeatures?: {
-        showGitBlameInSeparateColumn?: boolean
+        enableExtensionsDecorationsColumnView?: boolean
     }
 }
 
 const isBlameForSelectedLinesEnabled = () =>
-    !sourcegraph.configuration.get<Settings>().get('experimentalFeatures')?.showGitBlameInSeparateColumn ||
+    !sourcegraph.configuration.get<Settings>().get('experimentalFeatures')?.enableExtensionsDecorationsColumnView ||
     sourcegraph.internal.clientApplication !== 'sourcegraph'
 
-const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()
+const decorationType =
+    sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType({ display: 'column' })
 
 const statusBarItemType = sourcegraph.app.createStatusBarItemType && sourcegraph.app.createStatusBarItemType()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,6 +3259,11 @@ grapheme-breaker@^0.3.2:
     brfs "^1.2.0"
     unicode-trie "^0.3.1"
 
+graphql@^15.4.0:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6583,10 +6583,10 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-sourcegraph@^25.3.0:
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-25.3.0.tgz#0ad58f40a6fb286ddaf5f441c28b2c1241098e94"
-  integrity sha512-677uVs3rq1gVeiKTZ6wrlq862dUIn02ZmEgxoPTfFMI3tlJWhdgFZOg2GpFEgFRoB1ct7rMMlRrI1cEQdB7Rkg==
+sourcegraph@^25.6.0:
+  version "25.6.0"
+  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-25.6.0.tgz#fc23822a8e207e25ff9bfc217dad4a14bfbd1e84"
+  integrity sha512-BKe/hugALfgMyM38ecWpeFLtXvVklq++aUpGlm4Y3fY8/ufbUE/FAaYchF9qkidli8Usef5xnDRCKbAfsPRpWA==
 
 spawn-wrap@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
First iteration on https://github.com/sourcegraph/sourcegraph/issues/17434
Depends on https://github.com/sourcegraph/sourcegraph/pull/36007

1. Turns off "blame for selected lines" mode if the client application is Sourcegraph and https://github.com/sourcegraph/sourcegraph/pull/36007 experimental feature is enabled.
2. Updates blame decoration text according to [design](https://www.figma.com/file/MzN5BUNI0OJ4gQyrKqT7Nw/Improve-git-blame-readability?node-id=246%3A11).


### Test plan
- [sideload extension](https://docs.sourcegraph.com/extensions/authoring/local_development#local-development-sideloading)
- ensure that new decoration text formatting is applied
- enable [experimental feature](https://github.com/sourcegraph/sourcegraph/pull/36007) and ensure that "blame for selected lines" is not available in Sourcegraph web app
- ensure browser extension still has "blame for selected lines" mode

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
