### PR TITLE
feat: remove decorations column display support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
           [
             "git.blame.decorations"
           ],
-          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || (clientApplication.isSourcegraph && experimentalFeatures.enableExtensionsDecorationsColumnView && 'file' || 'line')}",
+          "${(config.git.blame.decorations === 'line' && 'file') || (config.git.blame.decorations === 'file' && 'none') || 'line'}",
           null
         ],
         "category": "Git",
-        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || (clientApplication.isSourcegraph && experimentalFeatures.enableExtensionsDecorationsColumnView && 'Show blame for the whole file' || 'Show blame for selected lines')}",
+        "title": "${(config.git.blame.decorations === 'line' && 'Show blame for the whole file') || (config.git.blame.decorations === 'file' && 'Hide blame') || 'Show blame for selected lines'}",
         "actionItem": {
           "label": "Blame",
-          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || (clientApplication.isSourcegraph && experimentalFeatures.enableExtensionsDecorationsColumnView && 'Show Git blame line annotations for the whole file' || 'Show Git blame line annotations on selected lines')}",
-          "pressed": "((!clientApplication.isSourcegraph || !experimentalFeatures.enableExtensionsDecorationsColumnView) && config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
+          "description": "${(config.git.blame.decorations === 'line' && 'Show Git blame line annotations for the whole file') || (config.git.blame.decorations === 'file' && 'Hide Git blame line annotations') || 'Show Git blame line annotations on selected lines'}",
+          "pressed": "(config.git.blame.decorations === 'line') || (config.git.blame.decorations === 'file')",
           "iconURL": "https://raw.githubusercontent.com/sourcegraph/sourcegraph-git-extras/63dd95962c43b95b3f3a9ea2aa0165d6b38a958c/icon/git_logo.svg?sanitize=true"
         }
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,11 @@
         "git.blame.decorations": {
           "description": "Whether to decorate all lines in a file, only selected lines, or none at all.",
           "type": "string",
-          "enum": ["none", "line", "file"],
+          "enum": [
+            "none",
+            "line",
+            "file"
+          ],
           "default": "none"
         },
         "git.blame.showPreciseDate": {
@@ -140,7 +144,7 @@
     "prettier": "^1.19.1",
     "sinon": "^9.2.1",
     "source-map-support": "^0.5.12",
-    "sourcegraph": "^25.6.0",
+    "sourcegraph": "^25.7.0",
     "ts-node": "^8.10.2",
     "tslint": "^5.11.0",
     "typescript": "^4.1.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,18 +10,9 @@ export interface Settings {
     ['git.blame.lineDecorations']?: boolean
     ['git.blame.decorateWholeFile']?: boolean
     ['git.blame.showPreciseDate']?: boolean
-
-    experimentalFeatures?: {
-        enableExtensionsDecorationsColumnView?: boolean
-    }
 }
 
-const isBlameForSelectedLinesEnabled = () =>
-    !sourcegraph.configuration.get<Settings>().get('experimentalFeatures')?.enableExtensionsDecorationsColumnView ||
-    sourcegraph.internal.clientApplication !== 'sourcegraph'
-
-const decorationType =
-    sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType({ display: 'column' })
+const decorationType = sourcegraph.app.createDecorationType && sourcegraph.app.createDecorationType()
 
 const statusBarItemType = sourcegraph.app.createStatusBarItemType && sourcegraph.app.createStatusBarItemType()
 
@@ -41,7 +32,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
         // When the configuration or current file changes, publish new decorations.
         context.subscriptions.add(
             combineLatest(configurationChanges, selectionChanges).subscribe(([, { editor, selections }]) =>
-                decorate(editor, isBlameForSelectedLinesEnabled() ? selections : null)
+                decorate(editor, selections)
             )
         )
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6601,10 +6601,10 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-sourcegraph@^25.6.0:
-  version "25.6.0"
-  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-25.6.0.tgz#fc23822a8e207e25ff9bfc217dad4a14bfbd1e84"
-  integrity sha512-BKe/hugALfgMyM38ecWpeFLtXvVklq++aUpGlm4Y3fY8/ufbUE/FAaYchF9qkidli8Usef5xnDRCKbAfsPRpWA==
+sourcegraph@^25.7.0:
+  version "25.7.0"
+  resolved "https://registry.yarnpkg.com/sourcegraph/-/sourcegraph-25.7.0.tgz#fb1e7a0b7d0547447f524a1d0dcf18407e70cdbf"
+  integrity sha512-3Xdr480Ojkl9fZfaOH7xDy4N8YeQOyccNKVlObOJcj4SR7oFLOra1EFYoMrJPZ9axuD1hSi+34YCx5vocGlRzQ==
 
 spawn-wrap@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
Related issue: https://github.com/sourcegraph/sourcegraph/issues/39437

Removes blame decorations column view support added in https://github.com/sourcegraph/sourcegraph-git-extras/pull/276

Uses [sourcegraph](https://www.npmjs.com/package/sourcegraph) v25.7.0 released in https://github.com/sourcegraph/sourcegraph/pull/41124

### Test plan
Same as https://github.com/sourcegraph/sourcegraph/pull/41124
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
