### PR TITLE
fix: query hunks only if decorations enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,8 +53,11 @@ export function activate(context: sourcegraph.ExtensionContext): void {
     // brief flicker of the old state when the file is reopened.
     async function decorate(editor: sourcegraph.CodeEditor, selections: sourcegraph.Selection[] | null): Promise<void> {
         const settings = sourcegraph.configuration.get<Settings>().value
+        const decorations = settings['git.blame.decorations'] || 'none'
+        const shouldQueryBlameHunks = decorations === 'file' || (decorations === 'line' && selections?.length)
+
         try {
-            const hunks = await queryBlameHunks({ uri: editor.document.uri, sourcegraph })
+            const hunks = shouldQueryBlameHunks ? await queryBlameHunks({ uri: editor.document.uri, sourcegraph }) : []
             const now = Date.now()
 
             // Check if the extension host supports status bar items (Introduced in Sourcegraph version 3.26.0).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,10 +54,16 @@ export function activate(context: sourcegraph.ExtensionContext): void {
     async function decorate(editor: sourcegraph.CodeEditor, selections: sourcegraph.Selection[] | null): Promise<void> {
         const settings = sourcegraph.configuration.get<Settings>().value
         const decorations = settings['git.blame.decorations'] || 'none'
-        const shouldQueryBlameHunks = decorations === 'file' || (decorations === 'line' && selections?.length)
+        const shouldQueryBlameHunks = Boolean(decorations === 'file' || (decorations === 'line' && selections?.length))
 
         try {
-            const hunks = shouldQueryBlameHunks ? await queryBlameHunks({ uri: editor.document.uri, sourcegraph }) : []
+            const hunks = shouldQueryBlameHunks
+                ? await queryBlameHunks({
+                      uri: editor.document.uri,
+                      sourcegraph,
+                      selections: decorations === 'line' ? selections : null,
+                  })
+                : []
             const now = Date.now()
 
             // Check if the extension host supports status bar items (Introduced in Sourcegraph version 3.26.0).


### PR DESCRIPTION
Queries blame hunks only if a user has file or line decorations enabled in settings.
If blame decorations mode is 'line' query blame only for selected lines.


https://user-images.githubusercontent.com/25318659/202039812-a2454fbe-489c-417e-bbb8-b2988c0b8f28.mov


### Test plan
Manually tested that blame hunks are not requested when decorations are not enabled in user settings.
 
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
